### PR TITLE
Update to latest robotframework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.altran.gdc</groupId>
     <artifactId>robotframework-TestFXLibrary</artifactId>
-    <version>1.1.1</version>
+    <version>2.0.0</version>
 
     <name>Test Library - robotframework-TestFXLibrary</name>
     <url>http://www.company.com/department/project</url>
@@ -21,7 +21,7 @@
         <downloadJavados>true</downloadJavados>
         <java.version>11</java.version>
         <openjfx.version>11.0.2</openjfx.version>
-        <robotframework.version>3.1.1</robotframework.version>
+        <robotframework.version>4.0.3</robotframework.version>
         <xml.doclet.version>1.0.5</xml.doclet.version>
         <keywords.class>TestFXLibrary</keywords.class>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.robotframework</groupId>
             <artifactId>javalib-core</artifactId>
-            <version>1.2.1</version>
+            <version>2.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.testfx</groupId>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-core</artifactId>
-            <version>4.0.15-alpha</version>
+            <version>4.0.16-alpha</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -89,9 +89,9 @@
             <version>3.1.5</version>
         </dependency>
         <dependency>
-            <groupId>com.github.ombre42</groupId>
+            <groupId>org.robotframework</groupId>
             <artifactId>jrobotremoteserver</artifactId>
-            <version>3.0</version>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/TestFXLibrary.java
+++ b/src/main/java/TestFXLibrary.java
@@ -1,4 +1,5 @@
 import java.io.File;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import com.altran.gdc.robotframework.testfxlibrary.keywords.Timeout;
@@ -8,7 +9,7 @@ import com.altran.gdc.robotframework.testfxlibrary.utils.TimeoutConstants;
 import org.robotframework.javalib.library.AnnotationLibrary;
 
 import com.altran.gdc.robotframework.testfxlibrary.utils.Javadoc2Libdoc;
-import org.robotframework.javalib.library.RobotJavaLibrary;
+import org.robotframework.javalib.library.RobotFrameworkDynamicAPI;
 import org.robotframework.remoteserver.RemoteServer;
 
 /**
@@ -94,7 +95,7 @@ import org.robotframework.remoteserver.RemoteServer;
 
 //This class can't be moved to a named package.
 //Is necessary to have the class in the root path, otherwise the lib doesn't work in the RobotFramework.
-public class TestFXLibrary extends AnnotationLibrary implements RobotJavaLibrary {
+public class TestFXLibrary extends AnnotationLibrary implements RobotFrameworkDynamicAPI {
 
     /**
      * The list of keyword patterns for the AnnotationLibrary
@@ -149,8 +150,8 @@ public class TestFXLibrary extends AnnotationLibrary implements RobotJavaLibrary
     // ******************************
 
     @Override
-    public Object runKeyword(String keywordName, Object[] args) {
-        return super.runKeyword(keywordName, toStrings(args));
+    public Object runKeyword(String keywordName, List args) {
+        return super.runKeyword(keywordName, args);
     }
 
     @Override
@@ -166,27 +167,14 @@ public class TestFXLibrary extends AnnotationLibrary implements RobotJavaLibrary
         return keywordDocumentation;
     }
 
+    @Override
+    public List<String> getKeywordNames() {
+        return super.getKeywordNames();
+    }
+
     // ******************************
     // Internal Methods
     // ******************************
-
-    /**
-     * Convert all arguments in the object array to string
-     *
-     * @param args The arguments
-     * @return The arguments converted in String
-     */
-    protected Object[] toStrings(Object[] args) {
-        Object[] newArgs = new Object[args.length];
-        for (int i = 0; i < newArgs.length; i++) {
-            if (args[i].getClass().isArray()) {
-                newArgs[i] = args[i];
-            } else {
-                newArgs[i] = args[i].toString();
-            }
-        }
-        return newArgs;
-    }
 
     /**
      * Set default timeouts
@@ -205,9 +193,8 @@ public class TestFXLibrary extends AnnotationLibrary implements RobotJavaLibrary
     public static void main(String[] args) throws Exception {
         // use jrobotremoteserver to start library as a server in port 8270
         RemoteServer.configureLogging();
-        RemoteServer server = new RemoteServer();
+        RemoteServer server = new RemoteServer(8270);
         server.putLibrary("/", new TestFXLibrary());
-        server.setPort(8270);
         server.start();
     }
 }

--- a/src/main/java/com/altran/gdc/robotframework/testfxlibrary/keywords/Component.java
+++ b/src/main/java/com/altran/gdc/robotframework/testfxlibrary/keywords/Component.java
@@ -3,6 +3,7 @@ package com.altran.gdc.robotframework.testfxlibrary.keywords;
 import com.altran.gdc.robotframework.testfxlibrary.exceptions.TestFxLibraryNonFatalException;
 import com.altran.gdc.robotframework.testfxlibrary.utils.TestFxLibraryValidation;
 import javafx.scene.control.Control;
+import org.awaitility.core.ConditionTimeoutException;
 import org.robotframework.javalib.annotation.ArgumentNames;
 import org.robotframework.javalib.annotation.Autowired;
 import org.robotframework.javalib.annotation.RobotKeyword;
@@ -57,7 +58,14 @@ public class Component {
     @ArgumentNames({"identifier"})
     public int getMatchingLocatorCount(String identifier){
         TestFxLibraryValidation.validateArguments(identifier);
-        wait.waitUntilPageContains(identifier);
+
+        try {
+            wait.waitUntilPageContains(identifier);
+        } catch (ConditionTimeoutException e) {
+            //Silently ignore TimeoutException and return 0. (Expl.: Count should be 0 when no element found with given identifier.)
+            return 0;
+        }
+
         java.util.ArrayList<Object> count = new ArrayList<>();
         count.addAll(new FxRobot().lookup(identifier).queryAll());
         return count.size();

--- a/src/main/java/com/altran/gdc/robotframework/testfxlibrary/keywords/Misc.java
+++ b/src/main/java/com/altran/gdc/robotframework/testfxlibrary/keywords/Misc.java
@@ -105,7 +105,7 @@ public class Misc {
      *  The applicationKey that can be used with closeApplication.
      */
     @RobotKeyword
-    @ArgumentNames({"className" , "distinctiveName=null", "*args=null"})
+    @ArgumentNames({"className" , "distinctiveName=null", "*args"})
     public String startApplication(String className, String distinctiveName, String... args){
 
         TestFxLibraryValidation.validateArguments(className, distinctiveName);

--- a/src/test/resources/robotframework/testFXLibraryComponent.robot
+++ b/src/test/resources/robotframework/testFXLibraryComponent.robot
@@ -10,6 +10,10 @@ Test Get Matching Locator Count
     ${locator_count}=   Get Matching Locator Count    .button
     Should Be Equal     ${locator_count}    ${${default_btn_number}}
 
+Test Get Matching Locator Count not exist
+    ${locator_count}=   Get Matching Locator Count    .not_exist
+    Should Be Equal     ${locator_count}    0
+
 Test Get Tooltip Text
     ${default_tooltip}=    Set Variable    Test Tooltip
     ${tooltip_text}=     Get Tooltip Text    \#btntooltip

--- a/src/test/resources/robotframework/testFXLibraryList.robot
+++ b/src/test/resources/robotframework/testFXLibraryList.robot
@@ -8,8 +8,9 @@ Suite Teardown    Close Application
 Test Get List Items From ListView
     @{default_list_items}=      Set Variable    one     two     three      four     five    six     seven   eight
     @{list_items}=    Get List Items From ListView  \#listviewsimple
-    :FOR    ${item}    IN    @{list_items}
-    \    Should Contain     "${default_list_items}"     ${item}
+    FOR    ${item}    IN    @{list_items}
+        Should Contain     "${default_list_items}"     ${item}
+    END
 
 Test Get Selected Items From List
     ${default_list_item}=   Set Variable    one
@@ -77,8 +78,9 @@ Test List Selection Should Be
     @{should_be_selected}=      Set Variable    two     three    five
     Select Items From List View     \#listviewsimple    ${items_selection}
     ${selected_items}=   Get Selected Items From List   \#listviewsimple
-    :FOR    ${item}    IN    @{should_be_selected}
-    \    Should Contain     "${selected_items}"     ${item}
+    FOR    ${item}    IN    @{should_be_selected}
+        Should Contain     "${selected_items}"     ${item}
+    END
 
 Test Select Items From List View
     Clear Selection From List     \#listviewsimple

--- a/src/test/resources/robotframework/testFXLibraryTable.robot
+++ b/src/test/resources/robotframework/testFXLibraryTable.robot
@@ -31,8 +31,9 @@ Test Get Table Headers
 Test Get Table Values
     ${count}=    Get Table Values  \#tableView
     ${values}=  Set Variable    Jacob   Smith  jacob.smith@example.com      Isabella    Johnson     isabella.johnson@example.com    Ethan    Williams    ethan.williams@example.com      Emma    Jones   emma.jones@example.com      Michael     Brown       michael.brown@example.com
-    :FOR    ${item_it}    IN    @{values}
-    \    Should Contain     "${count}"     ${item_it}
+    FOR    ${item_it}    IN    @{values}
+        Should Contain     "${count}"     ${item_it}
+    END
 
 Test Get Table Cell Value
     ${count}    Get Table Cell Value  \#tableView   0   2

--- a/src/test/resources/robotframework/testFXLibraryWindow.robot
+++ b/src/test/resources/robotframework/testFXLibraryWindow.robot
@@ -40,8 +40,9 @@ Test Capture Screen
     Capture Screen
     Capture Screen
     Capture Screen
-    :FOR    ${index}  IN RANGE    1   4
-    \   File Should Exist   ${screens_directory}${screen_name}${index}.${file_format}
+    FOR    ${index}  IN RANGE    1   4
+        File Should Exist   ${screens_directory}${screen_name}${index}.${file_format}
+    END
 
 Test Get Component Position
     @{comp_position}=       Get Component Position      \#listviewsimple


### PR DESCRIPTION
Update dependencies:
project version to 2.0.0 (backward compatibility is not guaranteed)
org.ropotframework:robotframework version to 4.0.3
org.robotframework:javalib-core version to 2.0.3
org.testfx:testfx-core verstion to 4.0.16-alpha
com.github.ombre42 changed to org.robotframework
org.robotframework:jrobotremoteserver version to 4.0.1

Test:
- Fix deprecated FOR keyword usages
- Add new test for Get Matching Locator Count when the result is zero

Java Classes:
TestFXLibrary.java
- Change implementation of RobotJavaLibrary to RobotFrameworkDynamicAPI 
- Change runKeyword Object[] args to List args
- Add getKeywordNames method
- Remove unused toStrings()
- Add port of the server to the constructor of RemoteServer
- Remove deprecated setPort function call

Misc.java
- Fix too many argument error when keyword passes @{list} variable

Component.java
- Return 0 in getMatchingLocatorCount keyword when ConditionTimeoutException occurs